### PR TITLE
Use mirrored base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.8-slim-buster
+FROM quay.io/ssbarnea/python:3.8-slim-buster
+# Image above is just a mirror of ^ docker.io/python:3.8-slim-buster which we
+# had to manually create because at this moment quay.io has mirroring disabled
+# and our builds were randomly failing due to docker pull limiting us.
 # see https://pythonspeed.com/articles/base-image-python-docker-images/
 LABEL maintainer="Ansible <info@ansible.com>"
 

--- a/tools/mirror-base-image
+++ b/tools/mirror-base-image
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+docker pull python:3.8-slim-buster
+docker tag python:3.8-slim-buster quay.io/ssbarnea/python:3.8-slim-buster
+docker push quay.io/ssbarnea/python:3.8-slim-buster


### PR DESCRIPTION
Avoids build failures on quay.io due to docker pull rate limiting.
Includes utility mirror script.