### PR TITLE
Improve use of apt in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,10 @@ ENV PIP_INSTALL_ARGS="--pre"
 ENV PYTHONDONTWRITEBYTECODE=1
 
 RUN \
-apt update && \
-apt install -y ${PACKAGES} && \
-apt-get autoclean
+apt-get update && \
+apt-get install --no-install-recommends -y ${PACKAGES} && \
+apt-get clean && \
+rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt
 


### PR DESCRIPTION
> `apt` is discouraged by the linux distributions as an unattended tool as its interface may suffer changes between versions. Better use the more stable `apt-get` and `apt-cache`.

Recommended by: https://github.com/hadolint/hadolint/wiki/DL3027

> In addition, when you clean up the apt cache by removing /var/lib/apt/lists it reduces the image size, since the apt cache is not stored in a layer. Since the RUN statement starts with apt-get update, the package cache is always refreshed prior to apt-get install.

https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers