### PR TITLE
Workaround for podman deb package conflicts (Debian)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,12 @@ ENV ANSIBLE_FORCE_COLOR=1
 RUN \
 apt-get update && \
 apt install -y ${PACKAGES} && \
+# workaround for https://github.com/containers/podman/issues/8665
+echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list && \
 echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && \
 curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/Release.key | apt-key add - && \
 apt update && \
+apt-get -t buster-backports install -y libseccomp-dev && \
 apt-get install -y podman && \
 apt-get clean && \
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Apparently two days ago podman started to fail to install due
to conflicts and we need to more workarounds to install it.

Related: https://github.com/containers/podman/issues/8665