### PR TITLE
Add Molecule Inspec and Goss verifiers to toolset

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,8 @@ molecule-docker
 molecule-digitalocean
 molecule-ec2
 molecule-gce
+molecule-goss
+molecule-inspec
 molecule-libvirt
 molecule-lxd
 molecule-podman

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,8 @@ molecule-digitalocean==0.1
 molecule-docker==0.3.3
 molecule-ec2==0.3
 molecule-gce==0.2
+molecule-goss==1.1
+molecule-inspec==1.1
 molecule-libvirt==0.0.3
 molecule-lxd==0.1
 molecule-openstack==0.3


### PR DESCRIPTION
Adds `molecule-inspec` and `molecule-goss` to the toolset container for
Molecule use. We don't need to install Inspec or Goss in the container
as the plugins handle that as part of a verify run.

```
$ python -m tox -e deps
deps installed: click==7.1.2,pip-tools==5.5.0
deps run-test-pre: PYTHONHASHSEED='374250647'
deps run-test: commands[0] | pip-compile -q --allow-unsafe --no-annotate --output-file=requirements.txt requirements.in
deps run-test: commands[1] | bash -c 'git --no-pager diff --quiet || { git status --porcelain; git --no-pager diff; echo '"'"'ERROR: git in dirty status, reporting as failure'"'"'; exit 1; }'
___________________________________ summary ____________________________________
  deps: commands succeeded
  congratulations :)
```

CC: PR #62