### PR TITLE
feat: Add ssh into docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ git \
 gcc \
 gnupg \
 rsync \
+ssh \
 libyaml-dev \
 "
 


### PR DESCRIPTION
Adds the ssh package to the docker container.

This was present previously, perhaps just pulled in as a dependency of something else. I think it is very useful in the container and should probably be there by default.