### PR TITLE
Add back yamllint as dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 molecule --version && \
 molecule drivers && \
 python3 -m pip check && \
+yamllint --version && \
 which docker && \
 podman --version && \
 git --version

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ Generally the containers should bundle the latest stable versions of the tools b
 * [ansible-lint](https://pypi.org/project/ansible-lint/)
 * [molecule](https://pypi.org/project/molecule/) and most of its plugins
 * [pytest](https://pypi.org/project/pytest/) and several of its plugins
+* [yamllint](https://yamllint.readthedocs.io/en/stable/) which is used by
+  ansible-lint itself.

--- a/requirements.in
+++ b/requirements.in
@@ -5,16 +5,17 @@ ansible-lint  # this also brings ansible
 molecule
 molecule-azure
 molecule-containers
-molecule-docker
 molecule-digitalocean
+molecule-docker
 molecule-ec2
 molecule-gce
 molecule-goss
 molecule-inspec
 molecule-libvirt
 molecule-lxd
-molecule-podman
 molecule-openstack
+molecule-podman
 molecule-vagrant
 openstacksdk
 ruamel.yaml.clib>=0.2.2  # performance
+yamllint>=1.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ click==7.1.2
 colorama==0.4.4
 commonmark==0.9.1
 cookiecutter==1.7.2
-cryptography==3.4.6
+cryptography==3.4.7
 decorator==4.4.2
 distro==1.5.0
 docker==4.4.4
@@ -57,6 +57,7 @@ openstacksdk==0.55.0
 os-service-types==1.7.0
 packaging==20.9
 paramiko==2.7.2
+pathspec==0.8.1
 pbr==5.5.1
 pluggy==0.13.1
 poyo==0.5.0
@@ -69,9 +70,9 @@ python-slugify==4.0.1
 pyyaml==5.4.1
 requests==2.25.1
 requestsexceptions==1.4.0
-rich==9.13.0
+rich==10.0.0
 ruamel.yaml.clib==0.2.2
-ruamel.yaml==0.16.13
+ruamel.yaml==0.17.2
 selinux==0.2.1
 shellingham==1.4.0
 six==1.15.0
@@ -82,6 +83,7 @@ typing-extensions==3.7.4.3
 urllib3==1.26.4
 wcmatch==8.1.2
 websocket-client==0.58.0
+yamllint==1.26.0
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==54.2.0


### PR DESCRIPTION
This also includes a test, so we do not endup building an image
without yamllint inside.

Fixes: #120